### PR TITLE
add extra check for os file name limit

### DIFF
--- a/Core/CommonKit/Sources/CommonKit/Models/MockModel.swift
+++ b/Core/CommonKit/Sources/CommonKit/Models/MockModel.swift
@@ -208,9 +208,27 @@ public extension MockModel {
         fileName += metaData.id
         fileName += ".json"
 
+        if fileName.count > 256 {
+            logger.warning("File name length is out of limit. Trying to reduce...")
+            fileName = shortFilename
+        }
+
         return fileName
     }
-    
+
+    private var shortFilename: String {
+        var fileName = ""
+
+        if !metaData.scenario.isEmpty {
+            fileName += metaData.scenario + "_"
+        }
+
+        fileName += metaData.id
+        fileName += ".json"
+
+        return fileName
+    }
+
     ///  Mock detail file should be proper path, it's important for find and return mocks.
     ///
     /// Mock Detail File path rule:

--- a/Core/CommonKit/Tests/CommonKitTests/MockModelTests.swift
+++ b/Core/CommonKit/Tests/CommonKitTests/MockModelTests.swift
@@ -43,6 +43,12 @@ final class MockModelTests: XCTestCase {
         XCTAssertEqual(model.fileName, "www.trendyol.com_9271C0BE-9326-443F-97B8-1ECA29571FC3.json")
     }
 
+    func test_MockModel_longFileName_WithNoPath() throws {
+        try reCreate(url: "https://www.trendyol.com/aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus")
+
+        XCTAssertEqual(model.fileName, "9271C0BE-9326-443F-97B8-1ECA29571FC3.json")
+    }
+
     func test_MockModel_fileName_WithNoPathJustSlash() throws {
         try reCreate(url: "https://www.trendyol.com/")
 
@@ -53,6 +59,12 @@ final class MockModelTests: XCTestCase {
        try reCreate(scenario: "EmptyResponse")
 
         XCTAssertEqual(model.fileName, "aboutus_EmptyResponse_9271C0BE-9326-443F-97B8-1ECA29571FC3.json")
+    }
+
+    func test_MockModel_longfileName_WithScenario() throws {
+        try reCreate(url: "https://www.trendyol.com/aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus", scenario: "EmptyResponse")
+
+        XCTAssertEqual(model.fileName, "EmptyResponse_9271C0BE-9326-443F-97B8-1ECA29571FC3.json")
     }
 
     func test_MockModel_folderPath() {

--- a/Core/MockingStarCore/Tests/MockingStarCoreTests/FileSaverActorTests.swift
+++ b/Core/MockingStarCore/Tests/MockingStarCoreTests/FileSaverActorTests.swift
@@ -61,6 +61,37 @@ final class FileSaverActorTests: XCTestCase {
     }
 
     @MainActor
+    func test_saveFile_longFileName_SaveFilePath() async throws {
+        fileManager.stubbedFileExistResult = false
+
+        XCTAssertFalse(fileManager.invokedFileExist)
+        XCTAssertFalse(fileManager.invokedWrite)
+
+        let url = try XCTUnwrap(URL(string: "https://www.trendyol.com/aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus"))
+
+        try await actor.saveFile(mock: .init(metaData: .init(url: url,
+                                                             method: "GET",
+                                                             appendTime: .init(),
+                                                             updateTime: .init(),
+                                                             httpStatus: 200,
+                                                             responseTime: 0.15,
+                                                             scenario: "",
+                                                             id: "9271C0BE-9326-443F-97B8-1ECA29571FC3"),
+                                             requestHeader: "",
+                                             responseHeader: "",
+                                             requestBody: .init("hello 123"),
+                                             responseBody: .init("hello 321")),
+                                 mockDomain: "LocalDevelopment")
+
+
+        XCTAssertTrue(fileManager.invokedFileExist)
+        XCTAssertTrue(fileManager.invokedWrite)
+        XCTAssertEqual(fileManager.invokedWriteParametersList.map(\.url.absoluteString), ["file:///MockServer/Domains/LocalDevelopment/Mocks/aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus-aboutus/GET"])
+        XCTAssertEqual(fileManager.invokedWriteParametersList.map(\.fileName), ["9271C0BE-9326-443F-97B8-1ECA29571FC3.json"])
+    }
+
+
+    @MainActor
     func test_saveFile_FileExist_SaveFilePath() async throws {
         fileManager.stubbedFileExistResult = true
 


### PR DESCRIPTION
macOS file name limit is 256 character. Sometimes path + scenario + id can exceed this limit. Remove path if limit is exceeded.