### PR TITLE
Fix: Robust base64 and string fallback for body decoding (#73)

### DIFF
--- a/Core/Server/Package.resolved
+++ b/Core/Server/Package.resolved
@@ -1,0 +1,41 @@
+{
+  "pins" : [
+    {
+      "identity" : "anycodable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/yusufozgul/AnyCodable",
+      "state" : {
+        "revision" : "5ba97c1cf8bb630becc1864d728dce54225c4e3c",
+        "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "filemonitor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/aus-der-Technik/FileMonitor.git",
+      "state" : {
+        "revision" : "5adbe8f2383eac5148475ef84977806bbd33e8d7",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "flyingfox",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swhitty/FlyingFox.git",
+      "state" : {
+        "revision" : "00e4d51c57b4fbe4f011650f2f965d3bea1ba7c1",
+        "version" : "0.13.0"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
+        "version" : "1.14.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Core/Server/Sources/Server/Routes/HandleMock.swift
+++ b/Core/Server/Sources/Server/Routes/HandleMock.swift
@@ -137,4 +137,32 @@ private struct MockServerRequestModel: Codable {
         case header
         case body
     }
+
+    init(method: String, url: URL, header: [String: String]?, body: Data?) {
+        self.method = method
+        self.url = url
+        self.header = header
+        self.body = body
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        method = try container.decode(String.self, forKey: .method)
+        url = try container.decode(URL.self, forKey: .url)
+        header = try container.decodeIfPresent([String: String].self, forKey: .header)
+        
+        if let bodyString = try? container.decodeIfPresent(String.self, forKey: .body) {
+            if let data = Data(base64Encoded: bodyString) {
+                body = data
+            } else if let data = Data(base64Encoded: bodyString.padding(toLength: ((bodyString.count + 3) / 4) * 4, withPad: "=", startingAt: 0)) {
+                body = data
+            } else {
+                body = bodyString.data(using: .utf8)
+            }
+        } else if let bodyData = try? container.decodeIfPresent(Data.self, forKey: .body) {
+            body = bodyData
+        } else {
+            body = nil
+        }
+    }
 }

--- a/Core/Server/Tests/ServerTests/HandleMockTests.swift
+++ b/Core/Server/Tests/ServerTests/HandleMockTests.swift
@@ -83,6 +83,32 @@ final class HandleMockTests: XCTestCase {
         XCTAssertEqual(response.statusCode.code, 501)
     }
 
+    func test_handleRequest_POST_WithRawStringBodyFallback() async throws {
+        // Given
+        let url = URL(string: "https://api.example.com/users")!
+        let bodyContentString = "{\"address\": \"Al Karama الكرامة دبي\"}"
+        
+        let jsonStr = """
+        {
+          "method": "POST",
+          "url": "https://api.example.com/users",
+          "body": "\(bodyContentString.replacingOccurrences(of: "\"", with: "\\\""))"
+        }
+        """
+        let bodyData = Data(jsonStr.utf8)
+
+        mockHandler.stubbedResult = (status: 201, body: Data(), headers: [:])
+
+        let request = HTTPRequest.make(method: .POST, path: "/mock", body: bodyData)
+
+        // When
+        let response = try await sut.handleRequest(request)
+
+        // Then
+        XCTAssertEqual(response.statusCode.code, 201)
+        XCTAssertEqual(mockHandler.invokedHandleParameters?.body, Data(bodyContentString.utf8))
+    }
+
     // MARK: - GET Request Tests
 
     func test_handleRequest_GET_Success() async throws {


### PR DESCRIPTION
Closes #73

When the client passes a raw JSON string instead of a base64 encoded string (or a base64 string with missing padding), `JSONDecoder` currently crashes with `Encountered Data is not valid Base64`. This caused Mockingstar to fail at mocking requests that had Arabic characters in the body, as the payload wasn't valid strict base64.

This PR adds a custom `init(from decoder: Decoder)` to `MockServerRequestModel` which gracefully falls back:
1. Tries standard Base64 decoding.
2. Tries padded Base64 decoding (in case padding is missing).
3. Falls back to UTF-8 raw string bytes.

Also includes unit tests to ensure no regressions.